### PR TITLE
Fix json dependency

### DIFF
--- a/dockerfiles/squeeze/Dockerfile
+++ b/dockerfiles/squeeze/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update
 RUN apt-get install -y sensu
 RUN apt-get install -y build-essential
 RUN apt-get install -y ruby rubygems
+RUN gem install json -v 1.8.3 --no-ri --no-rdoc
 RUN gem install fpm -v 1.3.3 --no-ri --no-rdoc
 ADD fpm_build.sh /fpm_build.sh
 


### PR DESCRIPTION
Latest versions of json gem (version > 2) depend on a ruby version > 2, which is not available in squeeze. Setting a fixed < 2 version of json package fixes this error.
